### PR TITLE
fix(powershell): use $HOME for oh-my-posh config path to support any …

### DIFF
--- a/PowerShell/Microsoft.PowerShell_profile.ps1
+++ b/PowerShell/Microsoft.PowerShell_profile.ps1
@@ -1,4 +1,3 @@
-
 cls
 fastfetch
-oh-my-posh init pwsh --config "C:\Users\michii\.config\oh-my-posh\SenkoSan.json" | Invoke-Expression
+oh-my-posh init pwsh --config "$HOME\.config\oh-my-posh\SenkoSan.json" | Invoke-Expression


### PR DESCRIPTION
fix(powershell): use $HOME for oh-my-posh config path to support any user

Replaced hardcoded `C:\Users\<username>` path with `$HOME` so the config
resolves correctly for any user profile on Windows. This improves portability
and avoids issues when switching accounts.

⚠️ Not tested: Needs verification on a clean setup to confirm path expansion
works across different shells and environments.
